### PR TITLE
adds blank message when f1_score short circuits

### DIFF
--- a/model/evaluator.py
+++ b/model/evaluator.py
@@ -100,11 +100,11 @@ class eval_batch:
         calculate f1 score based on statics
         """
         if self.guess_count == 0:
-            return {'total': (0.0, 0.0, 0.0, 0.0)}
+            return {'total': (0.0, 0.0, 0.0, 0.0, '')}
         precision = self.overlap_count / float(self.guess_count)
         recall = self.overlap_count / float(self.gold_count)
         if precision == 0.0 or recall == 0.0:
-            return {'total', (0.0, 0.0, 0.0, 0.0)}
+            return {'total', (0.0, 0.0, 0.0, 0.0, '')}
         f = 2 * (precision * recall) / (precision + recall)
         accuracy = float(self.correct_labels) / self.total_labels
         message=""

--- a/model/evaluator.py
+++ b/model/evaluator.py
@@ -104,7 +104,7 @@ class eval_batch:
         precision = self.overlap_count / float(self.guess_count)
         recall = self.overlap_count / float(self.gold_count)
         if precision == 0.0 or recall == 0.0:
-            return {'total', (0.0, 0.0, 0.0, 0.0, '')}
+            return {'total': (0.0, 0.0, 0.0, 0.0, '')}
         f = 2 * (precision * recall) / (precision + recall)
         accuracy = float(self.correct_labels) / self.total_labels
         message=""


### PR DESCRIPTION
When recall was zero in the first epoch, code was crashing because it expect 5 elements in the tuple returned from f1_score. The message was missing in the default tuple returned.